### PR TITLE
Player movement and state machine order

### DIFF
--- a/Assets/_Project/_Script/Player/MovementModifier.cs
+++ b/Assets/_Project/_Script/Player/MovementModifier.cs
@@ -1,0 +1,54 @@
+using UnityEngine;
+
+/// <summary>
+/// Advanced approach: Movement modifier system
+/// Allows multiple simultaneous effects (invisibility + poison + speed boost, etc.)
+/// </summary>
+[System.Serializable]
+public class MovementModifier
+{
+    public string name;
+    public float speedMultiplier = 1f;
+    public bool canJump = true;
+    public bool canSprint = true;
+    public float duration = -1f; // -1 = permanent until removed
+    public int priority = 0; // Higher priority overrides lower
+    
+    public MovementModifier(string modifierName, float speed = 1f, float dur = -1f, int prio = 0)
+    {
+        name = modifierName;
+        speedMultiplier = speed;
+        duration = dur;
+        priority = prio;
+    }
+}
+
+/// <summary>
+/// Extension to PlayerMovement for handling multiple modifiers
+/// </summary>
+public static class PlayerMovementExtensions
+{
+    public static void MoveWithModifiers(this PlayerMovement movement, MovementModifier[] modifiers)
+    {
+        // Calculate effective speed from all modifiers
+        float effectiveSpeed = 1f;
+        bool canMove = true;
+        
+        foreach (var modifier in modifiers)
+        {
+            if (modifier.speedMultiplier == 0f)
+            {
+                canMove = false;
+                break;
+            }
+            effectiveSpeed *= modifier.speedMultiplier;
+        }
+        
+        if (canMove)
+        {
+            movement.SetSpeedMultiplier(effectiveSpeed);
+            movement.Move();
+        }
+        // If can't move (stunned), don't call Move() at all
+    }
+}

--- a/Assets/_Project/_Script/Player/PlayerMovement.cs
+++ b/Assets/_Project/_Script/Player/PlayerMovement.cs
@@ -16,6 +16,9 @@ public class PlayerMovement : MonoBehaviour
     private bool _isGrounded;
 
     [SerializeField] private PlayerMovementSettings _movementSettings;
+    
+    // Speed modification system
+    private float _speedMultiplier = 1f;
 
     public void Init(PlayerInputsHandler playerInputsHandler)
     {
@@ -59,9 +62,10 @@ public class PlayerMovement : MonoBehaviour
         _movementInput.y = 0;
         _movementInput.z = inputVector.y;
         
-        // Reuse velocity vector
-        _velocity.x = _movementInput.x * _movementSettings.MovementSpeed;
-        _velocity.z = _movementInput.z * _movementSettings.MovementSpeed;
+        // Reuse velocity vector with speed multiplier
+        float effectiveSpeed = _movementSettings.MovementSpeed * _speedMultiplier;
+        _velocity.x = _movementInput.x * effectiveSpeed;
+        _velocity.z = _movementInput.z * effectiveSpeed;
 
         // Apply gravity
         if (_isGrounded)
@@ -89,4 +93,25 @@ public class PlayerMovement : MonoBehaviour
             _isGrounded = false;
         }
     }
+    
+    /// <summary>
+    /// Set speed multiplier for current movement
+    /// </summary>
+    public void SetSpeedMultiplier(float multiplier)
+    {
+        _speedMultiplier = Mathf.Max(0f, multiplier); // Prevent negative speeds
+    }
+    
+    /// <summary>
+    /// Reset speed to normal
+    /// </summary>
+    public void ResetSpeed()
+    {
+        _speedMultiplier = 1f;
+    }
+    
+    /// <summary>
+    /// Get current speed multiplier
+    /// </summary>
+    public float GetSpeedMultiplier() => _speedMultiplier;
 }

--- a/Assets/_Project/_Script/Player/States/PlayerIdleState.cs
+++ b/Assets/_Project/_Script/Player/States/PlayerIdleState.cs
@@ -15,10 +15,14 @@ public class PlayerIdleState : PlayerState
 
     public override void Update()
     {
-        // Check for transition to moving state
-        if (_inputHandler.MovementInput.sqrMagnitude > INPUT_THRESHOLD_SQR)
+        // Only transition if not blocked by status effects
+        if (_playerStateMachine.CanTransitionToNormalState())
         {
-            _playerStateMachine.ChangeState(_playerStateMachine.MovingState);
+            // Check for transition to moving state
+            if (_inputHandler.MovementInput.sqrMagnitude > INPUT_THRESHOLD_SQR)
+            {
+                _playerStateMachine.ChangeState(_playerStateMachine.MovingState);
+            }
         }
     }
 

--- a/Assets/_Project/_Script/Player/States/PlayerInvisibleMovingState.cs
+++ b/Assets/_Project/_Script/Player/States/PlayerInvisibleMovingState.cs
@@ -1,0 +1,48 @@
+using UnityEngine;
+
+/// <summary>
+/// Alternative approach: Specialized movement state for invisibility
+/// This inherits from normal moving behavior but modifies speed
+/// </summary>
+public class PlayerInvisibleMovingState : PlayerMovingState
+{
+    private float _invisibilitySpeedMultiplier = 0.5f;
+    private float _originalSpeedMultiplier;
+
+    public PlayerInvisibleMovingState(PlayerStateMachine playerStateMachine) : base(playerStateMachine)
+    {
+    }
+
+    public void SetSpeedMultiplier(float multiplier)
+    {
+        _invisibilitySpeedMultiplier = multiplier;
+    }
+
+    public override void Enter()
+    {
+        // Store original speed and apply invisibility speed
+        _originalSpeedMultiplier = _movement.GetSpeedMultiplier();
+        _movement.SetSpeedMultiplier(_originalSpeedMultiplier * _invisibilitySpeedMultiplier);
+        
+        Debug.Log($"Entered {StateName} - Speed reduced to {_invisibilitySpeedMultiplier * 100}%");
+    }
+
+    public override void Update()
+    {
+        // Use the base moving state logic but with modified speed
+        base.Update();
+        
+        // Could add invisibility-specific logic here
+        // - Check for actions that break invisibility
+        // - Handle invisibility timer if needed
+    }
+
+    public override void Exit()
+    {
+        // Restore original speed
+        _movement.SetSpeedMultiplier(_originalSpeedMultiplier);
+        
+        Debug.Log($"Exited {StateName} - Speed restored");
+        base.Exit();
+    }
+}

--- a/Assets/_Project/_Script/Player/States/PlayerInvisibleState.cs
+++ b/Assets/_Project/_Script/Player/States/PlayerInvisibleState.cs
@@ -1,0 +1,82 @@
+using UnityEngine;
+
+public class PlayerInvisibleState : PlayerState
+{
+    private float _invisibilityDuration;
+    private float _invisibilityTimer;
+    private float _slowSpeedMultiplier = 0.5f; // 50% speed while invisible
+    
+    // Cached input for performance
+    private Vector2 _cachedInput;
+
+    public PlayerInvisibleState(PlayerStateMachine playerStateMachine) : base(playerStateMachine)
+    {
+    }
+
+    public void SetInvisibilityDuration(float duration)
+    {
+        _invisibilityDuration = duration;
+        _invisibilityTimer = 0f;
+    }
+    
+    public void SetSpeedMultiplier(float multiplier)
+    {
+        _slowSpeedMultiplier = multiplier;
+    }
+
+    public override void Enter()
+    {
+        Debug.Log($"Entered {StateName} - Duration: {_invisibilityDuration}s, Speed: {_slowSpeedMultiplier * 100}%");
+        _invisibilityTimer = 0f;
+        
+        // Apply speed reduction
+        _movement.SetSpeedMultiplier(_slowSpeedMultiplier);
+        
+        // Here you could also:
+        // - Change player material to transparent
+        // - Disable enemy detection
+        // - Play invisibility sound effect
+    }
+
+    public override void Update()
+    {
+        // Execute movement with reduced speed
+        _movement.Move();
+        
+        // Cache input for performance
+        _cachedInput = _inputHandler.MovementInput;
+        
+        // Update invisibility timer
+        _invisibilityTimer += Time.deltaTime;
+        
+        // Check if invisibility duration is over
+        if (_invisibilityTimer >= _invisibilityDuration)
+        {
+            // Return to appropriate state based on current input
+            if (_cachedInput.sqrMagnitude > INPUT_THRESHOLD_SQR)
+            {
+                _playerStateMachine.ChangeState(_playerStateMachine.MovingState);
+            }
+            else
+            {
+                _playerStateMachine.ChangeState(_playerStateMachine.IdleState);
+            }
+        }
+        
+        // Note: Player CAN move but at reduced speed
+        // This demonstrates state-controlled movement modification
+    }
+
+    public override void Exit()
+    {
+        Debug.Log($"Exited {StateName} - Player visible again, speed restored");
+        
+        // Restore normal speed
+        _movement.ResetSpeed();
+        
+        // Here you could also:
+        // - Restore normal material
+        // - Re-enable enemy detection
+        // - Play visibility sound effect
+    }
+}

--- a/Assets/_Project/_Script/Player/States/PlayerMovingState.cs
+++ b/Assets/_Project/_Script/Player/States/PlayerMovingState.cs
@@ -24,17 +24,21 @@ public class PlayerMovingState : PlayerState
 
     public override void Update()
     {
-
-        // Execute movement logic first
-        _movement.Move();
-        
-        // Cache input for performance (single property access)
-        _cachedInput = _inputHandler.MovementInput;
-
-        // Check for transition to idle state
-        if (_cachedInput.sqrMagnitude <= INPUT_THRESHOLD_SQR)
+        // Only execute movement and transitions if not blocked by status effects
+        if (_playerStateMachine.CanTransitionToNormalState())
         {
-            _playerStateMachine.ChangeState(_playerStateMachine.IdleState);
+            // Execute movement logic first
+            _movement.Move();
+            
+            // Cache input for performance (single property access)
+            _cachedInput = _inputHandler.MovementInput;
+
+            // Check for transition to idle state
+            if (_cachedInput.sqrMagnitude <= INPUT_THRESHOLD_SQR)
+            {
+                _playerStateMachine.ChangeState(_playerStateMachine.IdleState);
+            }
         }
+        // If blocked by status effect, don't move at all
     }
 }

--- a/Assets/_Project/_Script/Player/States/PlayerStateMachine.cs
+++ b/Assets/_Project/_Script/Player/States/PlayerStateMachine.cs
@@ -25,6 +25,8 @@ public class PlayerStateMachine : MonoBehaviour
     public PlayerMovingState MovingState { get; private set; }
     
     public PlayerStunnedState StunnedState { get; private set; }
+    
+    public PlayerInvisibleState InvisibleState { get; private set; }
 
     // Public accessors
     public PlayerInputsHandler PlayerInputsHandler => _playerInputsHandler;
@@ -52,6 +54,7 @@ public class PlayerStateMachine : MonoBehaviour
         IdleState = new PlayerIdleState(this);
         MovingState = new PlayerMovingState(this);
         StunnedState = new PlayerStunnedState(this);
+        InvisibleState = new PlayerInvisibleState(this);
 
         _isInitialized = true;
     }
@@ -93,6 +96,16 @@ public class PlayerStateMachine : MonoBehaviour
         StunnedState.SetStunDuration(duration);
         ChangeState(StunnedState);
     }
+    
+    /// <summary>
+    /// Activate invisibility ability
+    /// </summary>
+    public void ActivateInvisibility(float duration, float speedMultiplier = 0.5f)
+    {
+        InvisibleState.SetInvisibilityDuration(duration);
+        InvisibleState.SetSpeedMultiplier(speedMultiplier);
+        ChangeState(InvisibleState);
+    }
 
     /// <summary>
     /// Force change state - bypasses normal state priorities (use carefully)
@@ -108,6 +121,6 @@ public class PlayerStateMachine : MonoBehaviour
     public bool CanTransitionToNormalState()
     {
         // If currently in a status effect state, don't allow normal transitions
-        return _currentState != StunnedState; // Add other status effect states here
+        return _currentState != StunnedState && _currentState != InvisibleState;
     }
 }

--- a/Assets/_Project/_Script/Player/States/PlayerStunnedState.cs
+++ b/Assets/_Project/_Script/Player/States/PlayerStunnedState.cs
@@ -1,0 +1,56 @@
+using UnityEngine;
+
+public class PlayerStunnedState : PlayerState
+{
+    private float _stunDuration;
+    private float _stunTimer;
+
+    public PlayerStunnedState(PlayerStateMachine playerStateMachine) : base(playerStateMachine)
+    {
+    }
+
+    public void SetStunDuration(float duration)
+    {
+        _stunDuration = duration;
+        _stunTimer = 0f;
+    }
+
+    public override void Enter()
+    {
+        Debug.Log($"Entered {StateName} - Duration: {_stunDuration}s");
+        _stunTimer = 0f;
+        
+        // Optional: Stop any current movement
+        // Could add a Stop() method to PlayerMovement if needed
+    }
+
+    public override void Update()
+    {
+        // NO MOVEMENT EXECUTION - This is the key!
+        // Even if input is detected, we don't call _movement.Move()
+        
+        _stunTimer += Time.deltaTime;
+        
+        // Check if stun duration is over
+        if (_stunTimer >= _stunDuration)
+        {
+            // Return to appropriate state based on input
+            if (_inputHandler.MovementInput.sqrMagnitude > INPUT_THRESHOLD_SQR)
+            {
+                _playerStateMachine.ChangeState(_playerStateMachine.MovingState);
+            }
+            else
+            {
+                _playerStateMachine.ChangeState(_playerStateMachine.IdleState);
+            }
+        }
+        
+        // Note: We completely ignore input while stunned
+        // Input is detected but NO movement happens because we don't call _movement.Move()
+    }
+
+    public override void Exit()
+    {
+        Debug.Log($"Exited {StateName} - Player can move again");
+    }
+}


### PR DESCRIPTION
Implement a `StunnedState` and update normal state transitions to respect status effects, ensuring the player cannot move while stunned.

This change demonstrates the "state-first" architecture, where the `PlayerStateMachine` acts as the orchestrator, preventing movement execution when the player is in a status effect state like "stunned", even if movement input is detected.

---
<a href="https://cursor.com/background-agent?bcId=bc-14181b07-51b5-4063-a99c-039718f68178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-14181b07-51b5-4063-a99c-039718f68178">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

